### PR TITLE
Lost Boolean params while Request signing

### DIFF
--- a/src/Factory/TopRequestFactory.php
+++ b/src/Factory/TopRequestFactory.php
@@ -264,6 +264,8 @@ class TopRequestFactory implements TopRequestFactoryInterface
      *
      * @return string|resource|null
      * @todo Arrays will be encoded to JSON. Is this correct? Press X to doubt.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     private function castValue($value)
     {

--- a/src/Factory/TopRequestFactory.php
+++ b/src/Factory/TopRequestFactory.php
@@ -274,6 +274,7 @@ class TopRequestFactory implements TopRequestFactoryInterface
             case 'NULL':
                 return $value;
             case 'boolean':
+                return $value ? 'true' : 'false';
             case 'integer':
             case 'double':
             case 'string':

--- a/src/TopClient/TopClient.php
+++ b/src/TopClient/TopClient.php
@@ -255,7 +255,7 @@ class TopClient implements TopClientInterface
         try {
             $httpResponse = $this->httpClient->sendRequest($httpRequest);
         } catch (ClientExceptionInterface $exception) {
-            throw new TopClientException(sprintf('Error sending request: %s', $exception->getMessage()), $exception);
+            throw new TopClientException(sprintf('Error sending request: %s', $exception->getMessage()), 0, $exception);
         }
 
         $bodyData = self::getBodyContents($httpResponse->getBody());

--- a/tests/RetailCrm/Tests/TopClient/ClientTest.php
+++ b/tests/RetailCrm/Tests/TopClient/ClientTest.php
@@ -141,7 +141,7 @@ EOF;
                     'app_key' => self::getEnvAppKey(),
                     'method' => 'aliexpress.solution.seller.category.tree.query',
                     'category_id' => '5090300',
-                    'filter_no_permission' => 1,
+                    'filter_no_permission' => 'true',
                     'session' => self::getEnvToken()
                 ]),
             $this->responseJson(200, $json)


### PR DESCRIPTION
You lost boolean values while generating sign.
Example: `SolutionSellerCategoryTreeQuery::$filterNoPermission = false`