### PR TITLE
Double filtering seems to be overkill

### DIFF
--- a/src/Service/RequestDataFilter.php
+++ b/src/Service/RequestDataFilter.php
@@ -25,12 +25,12 @@ class RequestDataFilter
      */
     public function filterBinaryFromRequestData(array $params): array
     {
-        return array_filter(array_filter(
+        return array_filter(
             $params,
             static function ($item) {
                 return !($item instanceof FileItemInterface);
             }
-        ));
+        );
     }
 
     /**


### PR DESCRIPTION
`array_filter(['a' => '1', 'b' => '0']; // => ['a' => 1]`
So, if you pass any _param_ to request with `(string) 0` or `(int) 0`, your **sign** will be wrong (generate without this _param_)